### PR TITLE
Changes upload_url_token to GITHUB_TOKEN

### DIFF
--- a/.github/actions/upload-release-asset/action.yml
+++ b/.github/actions/upload-release-asset/action.yml
@@ -56,7 +56,7 @@ runs:
         url=$(echo "${{ inputs.upload_url }}?name=${{ inputs.asset_name }}" | sed -e 's/{[^}]*}//')
         response=$(curl \
         -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer ${{ inputs.upload_url_token }}" \
+        -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         -H "Content-Type: ${{ inputs.asset_content_type }}" \
         -X POST ${url} \

--- a/.github/workflows/release-actions-workflow.yml
+++ b/.github/workflows/release-actions-workflow.yml
@@ -61,18 +61,20 @@ jobs:
       - name: Upload 'upload-release-asset'
         id: upload_release_asset
         uses: ./.github/actions/upload-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          upload_url_token: ${{ secrets.GITHUB_TOKEN }}
           asset_path: ${{steps.download.outputs.download-path}}/upload-release-asset.zip
           asset_name: upload-release-asset-${{ github.ref_name }}.zip
 
       - name: Upload LICENSE
         id: upload_license
         uses: ./.github/actions/upload-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          upload_url_token: ${{ secrets.GITHUB_TOKEN }}
           asset_path: ${{steps.download.outputs.download-path}}/license/LICENSE
           asset_name: LICENSE
           asset_content_type: text/plain


### PR DESCRIPTION
It turns out `upload_url_token` was not needed under `with` as composite actions can take an `env`.

This change allows for a complete match of the original `actions/upload-release-asset` interface, making switching very easy. 